### PR TITLE
Fix #1 - Configure rollup to serve content from the nonprod environment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+OWLREPO_URL=https://owlrepo-nonprod.wl.r.appspot.com

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /public/vendor/
 
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Navigate to [localhost:5000](http://localhost:5000). You should see your app
 running. Edit a component file in `src`, save it, and reload the page to see
 your changes.
 
-By default, the server will only respond to requests from localhost. To allow
-connections from other computers, edit the `sirv` commands in package.json to
-include the option `--host 0.0.0.0`.
+Use a browser addon like [CORS
+Everywhere](https://addons.mozilla.org/en-US/firefox/addon/cors-everywhere/) in
+Firefox or [Allow
+CORS](https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf?hl=en)
+in Chrome during development. This is required because the client will be making
+cross-origin requests. API calls may be relative to root (e.g. `/api`) in
+production.
 
 ## Building and running in production mode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,6 +484,12 @@
         "path-type": "^4.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-replace": "^2.3.4",
+    "dotenv": "^8.2.0",
     "mdsvex": "^0.8.9",
     "rollup": "^2.34.2",
     "rollup-plugin-copy": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public"
+    "start": "sirv public --single"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,8 @@ import replace from "@rollup/plugin-replace";
 import globals from "rollup-plugin-node-globals";
 import inject from "@rollup/plugin-inject";
 import { mdsvex } from "mdsvex";
+import dotenv from "dotenv";
+dotenv.config();
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -38,6 +40,16 @@ export default {
       "process.env.NODE_ENV": JSON.stringify(
         production ? "production" : "development"
       ),
+    }),
+    // There are instances of double quotes and backticks, so there needs to be
+    // a rule for each one.
+    replace({
+      "/api": production ? "/api" : `"${process.env.OWLREPO_URL}/api`,
+      delimiters: ['"', ""],
+    }),
+    replace({
+      "/api": production ? "/api" : `\`${process.env.OWLREPO_URL}/api`,
+      delimiters: ["`", ""],
     }),
     // fix missing moment import inside of tabulator
     inject({


### PR DESCRIPTION
Fixes #1 by replacing instances of `/api` with the path to the nonprod environment at https://owlrepo-nonprod.wl.r.appspot.com. In order to use this locally, CORS must be allowed everywhere. 

