### PR TITLE
Add component for top uploaders

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,11 +44,11 @@ export default {
     // There are instances of double quotes and backticks, so there needs to be
     // a rule for each one.
     replace({
-      "/api": production ? "/api" : `"${process.env.OWLREPO_URL}/api`,
+      "/api": production ? '"/api' : `"${process.env.OWLREPO_URL}/api`,
       delimiters: ['"', ""],
     }),
     replace({
-      "/api": production ? "/api" : `\`${process.env.OWLREPO_URL}/api`,
+      "/api": production ? "`/api" : `\`${process.env.OWLREPO_URL}/api`,
       delimiters: ["`", ""],
     }),
     // fix missing moment import inside of tabulator

--- a/src/components/TopUploaders.svelte
+++ b/src/components/TopUploaders.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { onMount } from "svelte";
+  import Tabulator from "tabulator-tables";
+
+  onMount(async () => {
+    let resp = await fetch("/api/v1/query/top_uploaders");
+    let data = await resp.json();
+    let table = new Tabulator("#top_uploaders", {
+      data: data,
+      layout: "fitColumns",
+      columns: [
+        { title: "Uploader Thumbprint", field: "client_thumbprint" },
+        { title: "Uploads (last 7 days)", field: "n" }
+      ]
+    });
+  });
+</script>
+
+<div id="top_uploaders" />

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -3,6 +3,7 @@
   import ActivityHeatmap from "../components/ActivityHeatmap.svelte";
   import PriceQuantityCharts from "../components/PriceQuantityCharts.svelte";
   import SearchItemIndex from "../components/SearchItemIndex.svelte";
+  import TopUploaders from "../components/TopUploaders.svelte";
   import FrontMatter from "../docs/FrontMatter.svx";
   import IndexDescription from "../docs/IndexDescription.svx";
   import References from "../docs/References.svx";
@@ -69,6 +70,11 @@
   <ActivityHeatmap {data} max_range={14} />
 {/await}
 
+<br />
+
+<h3>Top Uploaders</h3>
+
+<TopUploaders />
 <br />
 
 <h3>Recent Uploads</h3>


### PR DESCRIPTION
This adds a small component to show top uploaders in the last 7 day:

![image](https://user-images.githubusercontent.com/70861751/101867426-fbdd0600-3b2f-11eb-836e-e4c1392dd80e.png)

This also fixes a small bug in the rollup definition for production deployment.