### PR TITLE
Fix single digit hour on mac screenshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "owlrepo-client",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2724,12 +2724,19 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "polka": {
-      "version": "1.0.0-next.11",
-      "resolved": "https://registry.npmjs.org/polka/-/polka-1.0.0-next.11.tgz",
-      "integrity": "sha512-M/HBkS6ILksrDq7uvktCTev81OzuLwNtpxMyYdUhxLKQlMWdsu789XMotQU+p8JY8CM8vx8ML0HudyWjRus/lg==",
+      "version": "1.0.0-next.15",
+      "resolved": "https://registry.npmjs.org/polka/-/polka-1.0.0-next.15.tgz",
+      "integrity": "sha512-zBCZO40+USkSj0GDHMqufthqk4TIRc9xVGd50LbMvYNEwGHK8dZczLBQtw9pPHBM+i/Xg7ed7+c+r6J68XkWLg==",
       "requires": {
-        "@polka/url": "^1.0.0-next.11",
+        "@polka/url": "^1.0.0-next.15",
         "trouter": "^3.1.0"
+      },
+      "dependencies": {
+        "@polka/url": {
+          "version": "1.0.0-next.15",
+          "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
+          "integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA=="
+        }
       }
     },
     "popper.js": {
@@ -3150,9 +3157,9 @@
       "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g=="
     },
     "trouter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/trouter/-/trouter-3.1.0.tgz",
-      "integrity": "sha512-3Swwu638QQWOefHLss9cdyLi5/9BKYmXZEXpH0KOFfB9YZwUAwHbDAcoYxaHfqAeFvbi/LqAK7rGkhCr1v1BJA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/trouter/-/trouter-3.2.0.tgz",
+      "integrity": "sha512-rLLXbhTObLy2MBVjLC+jTnoIKw99n0GuJs9ov10J870vDw5qhTurPzsDrudNtBf5w/CZ9ctZy2p2IMmhGcel2w==",
       "requires": {
         "regexparam": "^1.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owlrepo-client",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "repository": "https://github.com/geospiza-fortis/owlrepo-client",
   "license": "MIT",
   "scripts": {

--- a/src/components/Uploader.svelte
+++ b/src/components/Uploader.svelte
@@ -41,7 +41,7 @@
     }
     let target = results[1].replace(/_/g, " ");
     // local AM/PM mode, ensure that this is being parsed strictly
-    let date = moment(target, "YYYY-MM-DD at hh.mm.ss A", true);
+    let date = moment(target, "YYYY-MM-DD at h.mm.ss A", true);
     if (!date.isValid()) {
       // try again in 24 hour mode
       date = moment(target, "YYYY-MM-DD at HH.mm.ss", true);


### PR DESCRIPTION
Names like `Screen Shot 2020-09-04 at 9.12.10 PM.png` were not being parsed correctly because the hour digit did not have two digits.